### PR TITLE
show jps main parameter

### DIFF
--- a/bin/as.sh
+++ b/bin/as.sh
@@ -377,9 +377,9 @@ update_if_necessary()
 call_jps()
 {
     if [ "${VERBOSE}" = true ] ; then
-        "${JAVA_HOME}"/bin/jps -l -v
+        "${JAVA_HOME}"/bin/jps -l -m -v
     else
-        "${JAVA_HOME}"/bin/jps -l
+        "${JAVA_HOME}"/bin/jps -l -m
     fi
 }
 


### PR DESCRIPTION
a process may be launched in the same class or in the same Jar file. so, show the main parameters to identify the process trying to find.